### PR TITLE
Feature/update apiController and counts

### DIFF
--- a/ArvidsonFoto/Controllers/ApiControllers/CategoryApiController.cs
+++ b/ArvidsonFoto/Controllers/ApiControllers/CategoryApiController.cs
@@ -90,20 +90,20 @@ public class CategoryApiController(ILogger<CategoryApiController> logger,
     /// <param name="categoryPath">The path with multiple category segments (e.g., "Faglar/Vadare/Pipare/Kustpipare")</param>
     /// <returns>Information about the resolved category</returns>
     [AllowAnonymous]
-    [HttpGet("/{*categoryPath}")]
     [HttpGet("Bilder/{*categoryPath}")]
     [HttpGet("ByPath/{*categoryPath}")]
     [HttpGet("ByPath/Bilder/{*categoryPath}")]
     [HttpGet("ByCategoryPath/{*categoryPath}")]
     public IActionResult ByCategoryPath(string categoryPath)
     {
-        categoryPath = Uri.UnescapeDataString(categoryPath);
         try
         {
             if (string.IsNullOrEmpty(categoryPath))
             {
                 return BadRequest("Category path cannot be empty");
             }
+            // Decode the URL-encoded path
+            categoryPath = Uri.UnescapeDataString(categoryPath);
 
             logger.LogInformation("Image - TestCategoryPath called with path: {CategoryPath}", categoryPath);
 

--- a/ArvidsonFoto/Controllers/ApiControllers/ImageApiController.cs
+++ b/ArvidsonFoto/Controllers/ApiControllers/ImageApiController.cs
@@ -386,6 +386,7 @@ public class ImageApiController(ILogger<ImageApiController> logger,
                 // Apply sorting and limiting
                 var sortedImages = ApplySortingAndLimit(images, sortBy, sortOrder, limit);
 
+                (_, var totalCategoryImageCount) = imageService.GetCountedCategoryId(currentCategoryId.Value);
 
                 var response = new ImageListResponse
                 {
@@ -393,7 +394,7 @@ public class ImageApiController(ILogger<ImageApiController> logger,
                     CategoryName = $"{matchingChildCategory?.Name ?? "Unknown"}",
                     CategoryUrl =  $"{matchingChildCategory?.UrlCategoryPathFull ?? "Unknown"}",
                     CategoryUrlWithAAO = Uri.EscapeDataString(categoryPath),
-                    ImageCategoryTotalCount = imageService.GetCountedCategoryId(currentCategoryId.Value),
+                    ImageCategoryTotalCount = totalCategoryImageCount,
                     DateLastPhotographedImage = sortedImages.OrderBy(x => x.DateImageTaken).FirstOrDefault()?.DateImageTaken,
                     DateLastUploadedImage = sortedImages.FirstOrDefault()?.DateUploaded,
                     ImageResultCount = sortedImages.Count,

--- a/ArvidsonFoto/Controllers/ApiControllers/ImageApiController.cs
+++ b/ArvidsonFoto/Controllers/ApiControllers/ImageApiController.cs
@@ -308,6 +308,7 @@ public class ImageApiController(ILogger<ImageApiController> logger,
     /// <param name="cancellationToken">Token to cancel the operation</param>
     /// <returns>A <see cref="ImageListResponse"/> with a list of <see cref="ImageDto"/> objects representing the images in the specified category path</returns>
     [AllowAnonymous]
+    [HttpGet("/api/Bilder/{*categoryPath}")]
     [HttpGet("Bilder/{*categoryPath}")]
     [HttpGet("ByPath/{*categoryPath}")]
     [HttpGet("ByPath/Bilder/{*categoryPath}")]
@@ -319,7 +320,6 @@ public class ImageApiController(ILogger<ImageApiController> logger,
         [FromQuery] int limit = 48,
         CancellationToken cancellationToken = default)
     {
-        categoryPath = Uri.UnescapeDataString(categoryPath);
         try
         {
             // Check for cancellation early
@@ -329,6 +329,8 @@ public class ImageApiController(ILogger<ImageApiController> logger,
             {
                 return BadRequest("Category path cannot be empty");
             }
+            // Decode the URL-encoded path
+            categoryPath = Uri.UnescapeDataString(categoryPath);
             
             logger.LogInformation("Image - GetImagesByCategoryPath called with path: {CategoryPath}", categoryPath);
             
@@ -395,8 +397,6 @@ public class ImageApiController(ILogger<ImageApiController> logger,
                     CategoryUrl =  $"{matchingChildCategory?.UrlCategoryPathFull ?? "Unknown"}",
                     CategoryUrlWithAAO = Uri.EscapeDataString(categoryPath),
                     ImageCategoryTotalCount = totalCategoryImageCount,
-                    DateLastPhotographedImage = sortedImages.OrderBy(x => x.DateImageTaken).FirstOrDefault()?.DateImageTaken,
-                    DateLastUploadedImage = sortedImages.FirstOrDefault()?.DateUploaded,
                     ImageResultCount = sortedImages.Count,
                     Images = sortedImages,
                     QueryLimit = limit,

--- a/ArvidsonFoto/Controllers/ApiControllers/ImageApiController.cs
+++ b/ArvidsonFoto/Controllers/ApiControllers/ImageApiController.cs
@@ -386,7 +386,7 @@ public class ImageApiController(ILogger<ImageApiController> logger,
                 // Apply sorting and limiting
                 var sortedImages = ApplySortingAndLimit(images, sortBy, sortOrder, limit);
 
-                (_, var totalCategoryImageCount) = imageService.GetCountedCategoryId(currentCategoryId.Value);
+                var totalCategoryImageCount = imageService.GetCountedCategoryId(currentCategoryId.Value);
 
                 var response = new ImageListResponse
                 {

--- a/ArvidsonFoto/Core/ApiResponses/ImageListResponse.cs
+++ b/ArvidsonFoto/Core/ApiResponses/ImageListResponse.cs
@@ -1,0 +1,46 @@
+﻿using ArvidsonFoto.Core.DTOs;
+
+namespace ArvidsonFoto.Core.ApiResponses;
+
+/// <summary> Response för en lista av bilder inom en efterfrågad kategori. </summary>
+public class ImageListResponse
+{
+    /// <summary> Kategori Id </summary>
+    public int CategoryId { get; set; } = -1;
+
+    /// <summary> Kategori Namn </summary>
+    public string CategoryName { get; set; }
+
+    /// <summary> Kategori URL med gamla formatet som innehåller åäö </summary>
+    public string CategoryUrlWithAAO { get; set; }
+
+    /// <summary> Kategori Url </summary>
+    public string CategoryUrl { get; set; }
+
+    /// <summary> Datum för senaste fotograferade bilden i denna kategori. </summary>
+    public DateTime? DateLastPhotographedImage { get; set; }
+
+    /// <summary> Datum för senaste uppladdade bilden i denna kategori. </summary>
+    public DateTime? DateLastUploadedImage { get; set; }
+
+    /// <summary> Antal bilder i denna kategori </summary>
+    public int ImageCategoryTotalCount { get; set; } = -1;
+
+    /// <summary> Totalt antal bilder i denna kategori. </summary>
+    public int ImageResultCount { get; set; }
+
+    /// <summary> Lista av bilder i denna kategori. </summary>
+    public List<ImageDto> Images { get; set; }
+
+
+    /// <summary> Querystring: Filter för sortering av resultatet </summary>
+    /// <remarks> Exempel: "uploaded" (datum när bilden laddades upp), "imagetaken" (datum när bilden togs) or "categoryname" (namn för kategorin) </remarks>
+    public string QuerySortBy { get; set; }
+
+    /// <summary> Querystring: Filter för sorteringsordning av resultatet (asc, desc) </summary>
+    /// <remarks> asc (alphabetically ascending order) or desc (reverse alphabetically descending order) </remarks>
+    public string QuerySortOrder { get; set; }
+
+    /// <summary> Querystring: Filter för att begränsa antal resultat via limit (0 = obegränsat resultat, 48 är standard) </summary>
+    public int QueryLimit { get; set; }
+}

--- a/ArvidsonFoto/Core/ApiResponses/ImageListResponse.cs
+++ b/ArvidsonFoto/Core/ApiResponses/ImageListResponse.cs
@@ -17,12 +17,6 @@ public class ImageListResponse
     /// <summary> Kategori Url </summary>
     public string CategoryUrl { get; set; }
 
-    /// <summary> Datum för senaste fotograferade bilden i denna kategori. </summary>
-    public DateTime? DateLastPhotographedImage { get; set; }
-
-    /// <summary> Datum för senaste uppladdade bilden i denna kategori. </summary>
-    public DateTime? DateLastUploadedImage { get; set; }
-
     /// <summary> Antal bilder i denna kategori </summary>
     public int ImageCategoryTotalCount { get; set; } = -1;
 

--- a/ArvidsonFoto/Core/Interfaces/IApiImageService.cs
+++ b/ArvidsonFoto/Core/Interfaces/IApiImageService.cs
@@ -66,8 +66,8 @@ public interface IApiImageService
     int GetCountedAllImages();
 
     /// <summary>Räknar alla bilder i en kategori</summary>
-    /// <returns>Antal med bilder i en specifik kategori</returns>
-    int GetCountedCategoryId(int categoryId);
+    /// <returns>En int med kategorins bilder, samt en int med kategorins bilder + alla dess childrens</returns>
+    (int, int) GetCountedCategoryId(int categoryId);
 
     /// <summary>Tar bort en bild asynkront</summary>
     /// <param name="id">ID för bilden som ska tas bort</param>

--- a/ArvidsonFoto/Core/Interfaces/IApiImageService.cs
+++ b/ArvidsonFoto/Core/Interfaces/IApiImageService.cs
@@ -66,7 +66,7 @@ public interface IApiImageService
     int GetCountedAllImages();
 
     /// <summary>Räknar alla bilder i en kategori</summary>
-    /// <returns>En int med kategorins bilder, samt en int med kategorins bilder + alla dess childrens</returns>
+    /// <returns>Alla kategorins bilder inklusive childs</returns>
     int GetCountedCategoryId(int categoryId);
 
     /// <summary>Tar bort en bild asynkront</summary>

--- a/ArvidsonFoto/Core/Interfaces/IApiImageService.cs
+++ b/ArvidsonFoto/Core/Interfaces/IApiImageService.cs
@@ -67,7 +67,7 @@ public interface IApiImageService
 
     /// <summary>Räknar alla bilder i en kategori</summary>
     /// <returns>En int med kategorins bilder, samt en int med kategorins bilder + alla dess childrens</returns>
-    (int, int) GetCountedCategoryId(int categoryId);
+    int GetCountedCategoryId(int categoryId);
 
     /// <summary>Tar bort en bild asynkront</summary>
     /// <param name="id">ID för bilden som ska tas bort</param>

--- a/ArvidsonFoto/Services/ApiImageService.cs
+++ b/ArvidsonFoto/Services/ApiImageService.cs
@@ -463,9 +463,11 @@ public class ApiImageService(ILogger<ApiImageService> logger, ArvidsonFotoCoreDb
     /// Gets the count of all images in a specified categoryId.
     /// </summary>
     /// <returns>A The total number of images for the.</returns>
-    public int GetCountedCategoryId(int categoryId)
+    public (int, int) GetCountedCategoryId(int categoryId)
     {
-        return _entityContext.TblImages.Where(x => x.ImageCategoryId == categoryId).Count();
+        var categoryImages = _entityContext.TblImages.Where(x => x.ImageCategoryId == categoryId).Count();
+        var childrenImages = _entityContext.TblImages.Where(x => x.ImageCategoryId == categoryId && x.ImageFamilyId == categoryId && x.ImageMainFamilyId == categoryId).Count();
+        return (categoryImages, childrenImages);
     }
 
     /// <summary>

--- a/ArvidsonFoto/Services/ApiImageService.cs
+++ b/ArvidsonFoto/Services/ApiImageService.cs
@@ -463,11 +463,13 @@ public class ApiImageService(ILogger<ApiImageService> logger, ArvidsonFotoCoreDb
     /// Gets the count of all images in a specified categoryId.
     /// </summary>
     /// <returns>A The total number of images for the.</returns>
-    public (int, int) GetCountedCategoryId(int categoryId)
+    public int GetCountedCategoryId(int categoryId)
     {
-        var categoryImages = _entityContext.TblImages.Where(x => x.ImageCategoryId == categoryId).Count();
-        var childrenImages = _entityContext.TblImages.Where(x => x.ImageCategoryId == categoryId && x.ImageFamilyId == categoryId && x.ImageMainFamilyId == categoryId).Count();
-        return (categoryImages, childrenImages);
+        var imagesCategoryCount = _entityContext.TblImages.Count(x => x.ImageCategoryId == categoryId);
+        var imagesFamilyCount = _entityContext.TblImages.Count(x => x.ImageFamilyId == categoryId);
+        var imagesMainFamilyCount = _entityContext.TblImages.Count(x => x.ImageMainFamilyId == categoryId);
+        var totalImagesForCategoryId = imagesCategoryCount + imagesFamilyCount + imagesMainFamilyCount;
+        return totalImagesForCategoryId;
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request introduces improvements to the image category API responses and refactors how image counts and category information are handled. The main focus is on providing more detailed and structured responses when fetching images by category path, as well as refining the logic for counting images within categories.

### API Response Improvements

* Added a new `ImageListResponse` class to encapsulate detailed information about image queries, including category metadata, image counts, and query parameters. The `GetImagesByCategoryPath` endpoint now returns this structured response instead of a plain list of images. [[1]](diffhunk://#diff-162c25e903511266ba83455176583a3261635a71d29e08b8111aa4ef60cd39a0R1-R40) [[2]](diffhunk://#diff-ca931183485a549b639ab9180844dbb900f4cf7ca887fd9a55baec873b359f71L386-R405)
* Updated the API documentation and response types to reflect the new response structure, including the use of `[ProducesResponseType<ImageListResponse>]` for better OpenAPI/Swagger support. [[1]](diffhunk://#diff-ca931183485a549b639ab9180844dbb900f4cf7ca887fd9a55baec873b359f71R1) [[2]](diffhunk://#diff-ca931183485a549b639ab9180844dbb900f4cf7ca887fd9a55baec873b359f71L308-R319)

### Category Path Resolution and Query Logic

* Improved category path traversal logic by introducing a variable for the matching child category, ensuring that category metadata is available for the response. [[1]](diffhunk://#diff-ca931183485a549b639ab9180844dbb900f4cf7ca887fd9a55baec873b359f71R346) [[2]](diffhunk://#diff-ca931183485a549b639ab9180844dbb900f4cf7ca887fd9a55baec873b359f71L362-R375)
* Ensured the category path is always URL-decoded before processing, preventing issues with encoded characters.

### Image Count Calculation

* Refined the image counting logic in `ApiImageService` so that image counts for a category now include images directly in the category as well as those in related family and main family categories. The interface documentation was updated to clarify this behavior. [[1]](diffhunk://#diff-10f8606a86b40ee661eea2cd2d3f120e3a56ca3bd58af470ac8a8544e6a4b51eL468-R472) [[2]](diffhunk://#diff-4b7613920140f90234f9c52d784655bfced702d48317d97fbc90ddd36692c24aL69-R69)

### Query Parameter Handling

* Changed the default sort order for image queries to descending (`desc`) and clarified the behavior of the `limit` parameter: a value of `0` now returns all matching images without limiting the result set. [[1]](diffhunk://#diff-ca931183485a549b639ab9180844dbb900f4cf7ca887fd9a55baec873b359f71L308-R319) [[2]](diffhunk://#diff-ca931183485a549b639ab9180844dbb900f4cf7ca887fd9a55baec873b359f71L428-R451)